### PR TITLE
chore(ci): 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install dependencies
         run: yarn install --check-files
-#      - name: give user docker permission so we can run tests
-#        run: chown $(whoami) /var/run/docker.sock
       - name: build
         run: npx projen build
       - id: self_mutation


### PR DESCRIPTION
Remove sudo chown to docker sock and use root user instead. To run the tests after the build we need to access to docker, because cdk uses docker in a subprocess. To do that we need to grant permission to use docker.sock. Instead of running sudo chown we run the jsii container with the root user. 