### PR TITLE
fix(python): remove jmespath dependency

### DIFF
--- a/layer/Python/Dockerfile
+++ b/layer/Python/Dockerfile
@@ -19,7 +19,7 @@ RUN cd /asset && \
   # remove boto3 and botocore (already available in Lambda Runtime)
   rm -rf python/boto* && \
   # remove boto3 dependencies
-  rm -rf python/s3transfer* python/*dateutil* python/urllib3* python/six* && \
+  rm -rf python/s3transfer* python/*dateutil* python/urllib3* python/six* python/jmespath* && \
   # remove debugging symbols
   find python -name '*.so' -type f -exec strip "{}" \; && \
   # remove tests


### PR DESCRIPTION
This PR removes the jmespath dependency from the Python layer.

REASON: jmespath comes with botocore.
