### PR TITLE
feat(python): optimize Python layer by always building wheels

### DIFF
--- a/layer/Python/Dockerfile
+++ b/layer/Python/Dockerfile
@@ -12,7 +12,24 @@ WORKDIR /tmp
 
 RUN yum update -y && yum install -y zip unzip wget tar gzip binutils
 
-RUN pip install -t /asset/python aws-lambda-powertools$PACKAGE_SUFFIX
+# Install build essentials
+RUN yum install -y \
+  boost-devel \
+  jemalloc-devel \
+  bison \
+  make \
+  gcc \
+  gcc-c++ \
+  flex \
+  autoconf \
+  zip \
+  git \
+  ninja-build
+
+# Install cython to generate native code
+RUN pip install --upgrade pip wheel && pip install --upgrade cython
+
+RUN CFLAGS="-Os -g0 -s" pip install --no-binary pydantic -t /asset/python aws-lambda-powertools$PACKAGE_SUFFIX
 
 # Removing nonessential files
 RUN cd /asset && \

--- a/layer/Python/Dockerfile
+++ b/layer/Python/Dockerfile
@@ -28,7 +28,7 @@ RUN yum install -y \
 
 # Install cython to generate native code
 RUN pip install --upgrade pip wheel && pip install --upgrade cython
-
+# Optimize binary size and strip debugging symbols for optimum size
 RUN CFLAGS="-Os -g0 -s" pip install --no-binary pydantic -t /asset/python aws-lambda-powertools$PACKAGE_SUFFIX
 
 # Removing nonessential files


### PR DESCRIPTION
Always build wheels for Python layer. This results into a bigger layer, but data shows it to be faster on coldstart.

## Load tests results

Optimized == CFLAGS="-Os -g0 -s", with wheels (C extensions) == bigger package
Unoptimized == pure python == smaller package

### ARM64, 128MB, Empty handler

**Optimized layer:**
[{"coldStart":1,"count":147,"p50":111.904,"p90":125.4095,"p99":142.0987,"max":150.04}]

**Unoptimized layer:**
[{"coldStart":1,"count":151,"p50":111.1238,"p90":125.7861,"p99":146.8638,"max":149.75}]

### ARM64, 128MB, importing Parser and Logging

**Optimized layer:**
[{"coldStart":1,"count":119,"p50":446.2816,"p90":466.3461,"p99":489.7542,"max":493.14}]

**Unoptimized layer:**
[{"coldStart":1,"count":105,"p50":481.5028,"p90":505.6717,"p99":533.1811,"max":567.93}]

### X86_64, 128MB, Importing Parser and Logging

**Optimized layer:**
[{"coldStart":1,"count":108,"p50":469.1512,"p90":494.6738,"p99":571.8211,"max":572.25}]

**Unoptimized layer:**
[{"coldStart":1,"count":166,"p50":502.6482,"p90":541.7763,"p99":642.7576,"max":679.75}]