### PR TITLE
fix(python): force pydantic 1.x major version

### DIFF
--- a/layer/Python/Dockerfile
+++ b/layer/Python/Dockerfile
@@ -31,7 +31,7 @@ RUN yum install -y \
 # Install cython to generate native code
 RUN pip install --upgrade pip wheel && pip install --upgrade cython
 # Optimize binary size and strip debugging symbols for optimum size
-RUN CFLAGS="-Os -g0 -s" pip install --no-binary pydantic -t /asset/python "aws-lambda-powertools$PACKAGE_SUFFIX"
+RUN CFLAGS="-Os -g0 -s" pip install --no-binary pydantic==1.* -t /asset/python "aws-lambda-powertools$PACKAGE_SUFFIX"
 
 # Removing nonessential files
 RUN cd /asset && \


### PR DESCRIPTION
This change prevents pydantic 2.x to be included with the python layer.

Fixes https://github.com/orgs/awslabs/projects/51/views/18?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=24863755

[Pydantic 2.x will soon be released](https://docs.pydantic.dev/blog/pydantic-v2/) and requires some major changes to our powertools code.