### PR TITLE
chore: change references to Powertools for AWS Lambda

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -10,7 +10,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   majorVersion: 3,
   name: 'cdk-aws-lambda-powertools-layer',
   repositoryUrl: 'https://github.com/awslabs/cdk-aws-lambda-powertools-layer.git',
-  description: 'A lambda layer for AWS Powertools for python and typescript',
+  description: 'Powertools for AWS Lambda layer for python and typescript',
   devDeps: [
     '@types/prettier@2.6.0', // pin until breaking changes is resolved: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60310
   ],

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@
 
 ### LambdaPowertoolsLayer <a name="cdk-aws-lambda-powertools-layer.LambdaPowertoolsLayer" id="cdkawslambdapowertoolslayerlambdapowertoolslayer"></a>
 
-Defines a new Lambda Layer with Powertools for python library.
+Defines a new Lambda Layer containing Powertools for AWS Lambda.
 
 #### Initializers <a name="cdk-aws-lambda-powertools-layer.LambdaPowertoolsLayer.Initializer" id="cdkawslambdapowertoolslayerlambdapowertoolslayerinitializer"></a>
 
@@ -81,7 +81,7 @@ LambdaPowertoolsLayer.constructBuildArgs(runtimeFamily: RuntimeFamily, includeEx
 
 ### PowertoolsLayerProps <a name="cdk-aws-lambda-powertools-layer.PowertoolsLayerProps" id="cdkawslambdapowertoolslayerpowertoolslayerprops"></a>
 
-Properties for Powertools layer for python.
+Properties for the layer.
 
 #### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
 
@@ -159,7 +159,7 @@ public readonly version: string;
 
 - *Type:* `string`
 
-The powertools package version from pypi repository.
+The package version from pypi repository.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@
 
 ### LambdaPowertoolsLayer <a name="cdk-aws-lambda-powertools-layer.LambdaPowertoolsLayer" id="cdkawslambdapowertoolslayerlambdapowertoolslayer"></a>
 
-Defines a new Lambda Layer containing Powertools for AWS Lambda.
+Defines a new Lambda Layer with Powertools for AWS Lambda (Python) library.
 
 #### Initializers <a name="cdk-aws-lambda-powertools-layer.LambdaPowertoolsLayer.Initializer" id="cdkawslambdapowertoolslayerlambdapowertoolslayerinitializer"></a>
 
@@ -81,7 +81,7 @@ LambdaPowertoolsLayer.constructBuildArgs(runtimeFamily: RuntimeFamily, includeEx
 
 ### PowertoolsLayerProps <a name="cdk-aws-lambda-powertools-layer.PowertoolsLayerProps" id="cdkawslambdapowertoolslayerpowertoolslayerprops"></a>
 
-Properties for the layer.
+Properties for Powertools for AWS Lambda (Python) Layer.
 
 #### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
 
@@ -99,7 +99,7 @@ const powertoolsLayerProps: PowertoolsLayerProps = { ... }
 | [`includeExtras`](#cdkawslambdapowertoolslayerpowertoolslayerpropspropertyincludeextras) | `boolean` | A flag for the extras dependencies (pydantic, aws-xray-sdk, etc.) This will increase the size of the layer significantly. If you don't use parsing, ignore it. |
 | [`layerVersionName`](#cdkawslambdapowertoolslayerpowertoolslayerpropspropertylayerversionname) | `string` | the name of the layer, will be randomised if empty. |
 | [`runtimeFamily`](#cdkawslambdapowertoolslayerpowertoolslayerpropspropertyruntimefamily) | [`aws-cdk-lib.aws_lambda.RuntimeFamily`](#aws-cdk-lib.aws_lambda.RuntimeFamily) | the runtime of the layer. |
-| [`version`](#cdkawslambdapowertoolslayerpowertoolslayerpropspropertyversion) | `string` | The powertools package version from pypi repository. |
+| [`version`](#cdkawslambdapowertoolslayerpowertoolslayerpropspropertyversion) | `string` | The Powertools for AWS Lambda package version from pypi repository. |
 
 ---
 
@@ -159,7 +159,7 @@ public readonly version: string;
 
 - *Type:* `string`
 
-The package version from pypi repository.
+The Powertools for AWS Lambda package version from pypi repository.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AWS Lambda powertools layer
+# Powertools for AWS Lambda Layer
 
 ## Why this project exists
 
-This is a custom construct that will create AWS Lambda Layer with AWS Powertools for Python or NodeJS library. There are different
+This is a custom construct that will create AWS Lambda Layer with Powertools for AWS Lambda for Python or NodeJS library. There are different
 ways how to create a layer and when working with CDK you need to install the library, create a zip file and wire it
 correctly. With this construct you don't have to care about packaging and dependency management. Create a construct
 and add it to your function. The construct is an extension of the
@@ -49,7 +49,7 @@ pip install cdk-aws-lambda-powertools-layer
 
 ### Python
 
-A single line will create a layer with powertools for python. For NodeJS you need to specifically set the `runtimeFamily: Runtime.NODEJS` property.
+A single line will create a layer with Powertools for AWS Lambda (Python). For NodeJS you need to specifically set the `runtimeFamily: Runtime.NODEJS` property.
 
 ```python
 from cdk_aws_lambda_powertools_layer import LambdaPowertoolsLayer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-aws-lambda-powertools-layer",
-  "description": "Creates Powertools for AWS Lambda layers with python and typescript",
+  "description": "Powertools for AWS Lambda layer for python and typescript",
   "repository": {
     "type": "git",
     "url": "https://github.com/awslabs/cdk-aws-lambda-powertools-layer.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-aws-lambda-powertools-layer",
-  "description": "A lambda layer for AWS Powertools for python and typescript",
+  "description": "Creates Powertools for AWS Lambda layers with python and typescript",
   "repository": {
     "type": "git",
     "url": "https://github.com/awslabs/cdk-aws-lambda-powertools-layer.git"

--- a/src/lambda-powertools-layer.ts
+++ b/src/lambda-powertools-layer.ts
@@ -99,7 +99,7 @@ export class LambdaPowertoolsLayer extends lambda.LayerVersion {
       layerVersionName: props?.layerVersionName ? props?.layerVersionName : undefined,
       license: 'MIT-0',
       compatibleRuntimes: getRuntimesFromRuntimeFamily(runtimeFamily),
-      description: `Lambda Powertools for ${languageName} [${compatibleArchitecturesDescription}]${
+      description: `Powertools for AWS Lambda (${languageName}) [${compatibleArchitecturesDescription}]${
         props?.includeExtras ? ' with extra dependencies' : ''
       } ${props?.version ? `version ${props?.version}` : 'latest version'}`.trim(),
       // Dear reader: I'm happy that you've stumbled upon this line too! You might wonder, why are we doing this and passing `undefined` when the list is empty?

--- a/src/lambda-powertools-layer.ts
+++ b/src/lambda-powertools-layer.ts
@@ -4,11 +4,11 @@ import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 
 /**
- * Properties for Powertools layer for python.
+ * Properties for Powertools for AWS Lambda (Python) Layer.
  */
 export interface PowertoolsLayerProps {
   /**
-   * The powertools package version from pypi repository.
+   * The Powertools for AWS Lambda package version from pypi repository.
    */
   readonly version?: string;
 
@@ -35,7 +35,7 @@ export interface PowertoolsLayerProps {
 }
 
 /**
- * Defines a new Lambda Layer with Powertools for python library.
+ * Defines a new Lambda Layer with Powertools for AWS Lambda (Python) library.
  */
 export class LambdaPowertoolsLayer extends lambda.LayerVersion {
   /**

--- a/test/lambda-powertools-python-layer.test.ts
+++ b/test/lambda-powertools-python-layer.test.ts
@@ -10,7 +10,7 @@ describe('with no configuration the construct', () => {
   const template = Template.fromStack(stack);
   test('synthesizes successfully', () => {
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Lambda Powertools for Python [x86_64] latest version',
+      Description: 'Powertools for AWS Lambda (Python) [x86_64] latest version',
     });
   });
 
@@ -41,7 +41,7 @@ describe('with arm64 architecture', () => {
   const template = Template.fromStack(stack);
   test('synthesizes successfully', () => {
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Lambda Powertools for Python [arm64] latest version',
+      Description: 'Powertools for AWS Lambda (Python) [arm64] latest version',
       CompatibleArchitectures: ['arm64'],
     });
   });
@@ -69,7 +69,7 @@ describe('with version configuration the construct', () => {
 
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Lambda Powertools for Python [x86_64] version 1.21.0',
+      Description: 'Powertools for AWS Lambda (Python) [x86_64] version 1.21.0',
     });
   });
 
@@ -88,7 +88,7 @@ describe('with version configuration the construct', () => {
     });
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Lambda Powertools for Python [x86_64] with extra dependencies version 1.22.0',
+      Description: 'Powertools for AWS Lambda (Python) [x86_64] with extra dependencies version 1.22.0',
     });
 
   });

--- a/test/lambda-powertools-python-layer.test.ts
+++ b/test/lambda-powertools-python-layer.test.ts
@@ -100,7 +100,7 @@ describe('with version configuration the construct', () => {
     });
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Lambda Powertools for Python [x86_64] with extra dependencies latest version',
+      Description: 'Powertools for AWS Lambda (Python) [x86_64] with extra dependencies latest version',
     });
   });
 });

--- a/test/lambda-powertools-typescript-layer.test.ts
+++ b/test/lambda-powertools-typescript-layer.test.ts
@@ -58,7 +58,7 @@ describe('with version configuration the construct', () => {
 
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: `Lambda Powertools for TypeScript [x86_64] version ${version}`,
+      Description: `Powertools for AWS Lambda (TypeScript) [x86_64] version ${version}`,
     });
   });
 

--- a/test/lambda-powertools-typescript-layer.test.ts
+++ b/test/lambda-powertools-typescript-layer.test.ts
@@ -12,7 +12,7 @@ describe('with minimal configuration the construct', () => {
   const template = Template.fromStack(stack);
   test('synthesizes successfully', () => {
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Lambda Powertools for TypeScript [x86_64] latest version',
+      Description: 'Powertools for AWS Lambda (TypeScript) [x86_64] latest version',
     });
   });
 


### PR DESCRIPTION
Finds references of "Lambda Powertoos" and replaces them with the new branding.